### PR TITLE
To leave a blank space between parentheses and shell commands

### DIFF
--- a/l
+++ b/l
@@ -5580,10 +5580,10 @@ function public_ip
 	CHECKMON=$(ifconfig | grep "mon")
 	if [[ "$CHECKMON" = "" ]]
 	then
-		PUBLICIP=$(curl -s ipinfo.io/ip)
+		PUBLICIP=$( curl -s ipinfo.io/ip ) 
 		if [[ "$PUBLICIP" = "" ]]
 		then
-			PUBLICIP=$(curl -s checkip.dyndns.org | sed -e 's/.*Current IP Address: //' -e 's/<.*$//')
+			PUBLICIP=$( curl -s checkip.dyndns.org | sed -e 's/.*Current IP Address: //' -e 's/<.*$//' )
 			if [[ "$PUBLICIP" = "" ]]
 			then
 				PUBLICIP="Connection error."


### PR DESCRIPTION
Without to leave a blank space between parentheses and shell commands in the Kali Linux system, causing the result is unable to return anything and the shell script freeze.