### PR TITLE
Fixing error line 10421 for WiFi-Pumpkin

### DIFF
--- a/l
+++ b/l
@@ -10418,6 +10418,7 @@ check_if_ks
 		cloned=$?
 		if [[ "$cloned" == 1 ]]
 		then
+			chmod +x installer.sh
 			./installer.sh --install
 		fi
 	}


### PR DESCRIPTION
Added chmod +x installer.sh to fix permission denied error when installing WiFi-Pumpkin