### PR TITLE
changing to updated service Command NetworkManager

### DIFF
--- a/l
+++ b/l
@@ -6707,7 +6707,7 @@ function stop_monitor
 		airmon-ng stop $WLANNM &>/dev/null && echo -e ""$YS"Done"$CE"" && O2=1 || echo -e ""$RS"Error stoping monitor mode."$CE""
 	fi
 	echo -e "Starting network-manager service..."
-	service network-manager start && echo -e ""$YS"Done"$CE"" && O3=1 || echo -e ""$RS"Error starting network-manager service"$CE""
+	service NetworkManager start && echo -e ""$YS"Done"$CE"" && O3=1 || echo -e ""$RS"Error starting NetworkManager service"$CE""
 }
 function spoof_email
 {


### PR DESCRIPTION
when I am disabling monitor mode using **lscript** its disables monitor mode but doesn't start network service I have to manually start it. then I have tested this script on multiple systems. but the result is the same. 
After changing network-manager to NetworkManager. Now it's working fine.
      network-manager is the symbolic link of NetworkManager.  but it's not working on some virtual machine. 
      so take a look at my contribution. if you found this helpful merge it.
      currently, I am testing this script if I found any issues. I will update it
